### PR TITLE
opentelemetry-instrumentation-redis 0.59b0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-redis" %}
-{% set version = "0.58b0" %}
+{% set version = "0.59b0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 6271f10a9ee0572f1c67f630b098326a4fe02b898c46a173942766c00307914a
+  sha256: d7f1c7c55ab57e10e0155c4c65d028a7e436aec7ccc7ccbf1d77e8cd12b55abd
 
 build:
   number: 0


### PR DESCRIPTION
opentelemetry-instrumentation-redis 0.59b0 

**Destination channel:** Defaults

### Links

- [PKG-11130]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python-contrib/tree/v0.59b0
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-redis-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-redis/0.59b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-redis/0.59b0

### Explanation of changes:

- new version number


[PKG-11130]: https://anaconda.atlassian.net/browse/PKG-11130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ