### PR TITLE
opentelemetry-instrumentation-redis 0.64b0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,23 @@
 {% set name = "opentelemetry-instrumentation-redis" %}
-{% set version = "0.59b0" %}
+{% set version = "0.64b0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: d7f1c7c55ab57e10e0155c4c65d028a7e436aec7ccc7ccbf1d77e8cd12b55abd
+  sha256: c37e194c1e8ff59944d5c2f18014ee18f244a103958b1f2482099525ae9099f9
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:
-    - python
     - pip
+    - python
     - hatchling
   run:
     - python


### PR DESCRIPTION
opentelemetry-instrumentation-redis 0.64b0 

**Destination channel:** Defaults

### Links

- [PKG-16299]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python-contrib/tree/v0.64b0
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-redis-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-redis/0.64b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-redis/0.64b0

### Explanation of changes:

- new version number


[PKG-16299]: https://anaconda.atlassian.net/browse/PKG-16299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ